### PR TITLE
adiciona iac postgres

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,6 +12,15 @@ provider "google" {
 #   service_account_email = var.service_account_email
 # }
 
+module "postgres" {
+  source                = "./modules/postgres"
+  project_id            = var.project_id
+  region                = var.region
+  zone                  = var.zone
+  machine_type          = var.machine_type
+  service_account_email = var.service_account_email
+}
+
 terraform {
   backend "gcs" {
     bucket = "terraform-tf-states-bi-aas-project"

--- a/terraform/modules/postgres/main.tf
+++ b/terraform/modules/postgres/main.tf
@@ -1,0 +1,9 @@
+resource "google_sql_database_instance" "main" {
+  name             = "main-instance"
+  database_version = "POSTGRES_15"
+  region           = "us-central1"
+
+  settings {
+    tier = "db-f1-micro"
+  }
+}

--- a/terraform/modules/postgres/main.tf
+++ b/terraform/modules/postgres/main.tf
@@ -1,9 +1,21 @@
 resource "google_sql_database_instance" "main" {
   name             = "main-instance"
   database_version = "POSTGRES_15"
-  region           = "us-central1"
+  region           = var.region
+  project          = var.project_id
 
   settings {
     tier = "db-f1-micro"
   }
+}
+
+resource "google_service_account" "db_sa" {
+  account_id   = "db-service-account"
+  display_name = "Database Service Account"
+}
+
+resource "google_project_iam_member" "db_sa_role" {
+  project = var.project_id
+  role    = "roles/cloudsql.admin"
+  member  = "serviceAccount:${google_service_account.db_sa.email}"
 }

--- a/terraform/modules/postgres/variables.tf
+++ b/terraform/modules/postgres/variables.tf
@@ -1,0 +1,24 @@
+variable "project_id" {
+  description = "ID do projeto no GCP"
+  type        = string
+}
+
+variable "region" {
+  description = "Região do GCP onde os recursos serão criados"
+  type        = string
+}
+
+variable "zone" {
+  description = "Zona do GCP onde a instância será criada"
+  type        = string
+}
+
+variable "machine_type" {
+  description = "Tipo de máquina da instância"
+  type        = string
+}
+
+variable "service_account_email" {
+  description = "E-mail da Service Account usada na instância"
+  type        = string
+}


### PR DESCRIPTION
## Resumo por Sourcery

Implantação:
- Adiciona uma instância de banco de dados Postgres à infraestrutura de implantação usando Terraform. A instância é provisionada na região us-central1 usando o tipo de máquina db-f1-micro e é gerenciada por um módulo dedicado dentro da configuração do Terraform.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Deployment:
- Add a Postgres database instance to the deployment infrastructure using Terraform. The instance is provisioned in the us-central1 region using the db-f1-micro machine type and is managed by a dedicated module within the Terraform configuration

</details>